### PR TITLE
Fit in Wakatime api convention to avoid 400 error

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -160,10 +160,10 @@ export default class ObsidianWakatime extends Plugin {
 				project: project,
 				language: lang,
 				is_write: isWrite,
-				cursorpos: cursorPosition,
-				lineno: line,
+				cursorpos: cursorPosition !== undefined ? cursorPosition + 1 : undefined,
+				lineno: line !== undefined ? line + 1 : undefined,
 				editor: 'Obsidian',
-				category: lang ? 'writing' : 'reading'
+				category: lang ? 'notes' : 'browsing'
 			})
 		})
 			.then(response => {


### PR DESCRIPTION
This may fix #21 .

When using this plugin with the official WakaTime API, I encountered repeated 400 Bad Request errors and activity tracking stopped working correctly.

With debug mode enabled, the outgoing heartbeat payload included values such as:

```
{
  cursorpos: 0,
  lineno: 0,
  category: "writing" // or "reading"
}
```

According to the official WakaTime heartbeat API JSON POST Data ( https://wakatime.com/developers#heartbeats ), lineno should start at 1, cursorpos should also start at 1, and category, when provided, should be one of the supported WakaTime categories such as coding, browsing, writing docs, notes, researching, or learning.

<img width="3008" height="1808" alt="image" src="https://github.com/user-attachments/assets/25bc84e4-6484-462c-9d13-797b9459e831" />

I confirmed this locally by patching the installed plugin under Vault/.obsidian/plugins/wakatime-kvh/. After converting lineno and cursorpos to 1-based values and replacing writing / reading with WakaTime-compatible categories, the 400 Bad Request errors disappeared and tracking started working again.

This PR applies the same fix to the plugin code.