### PR TITLE
Track scrolling and touch input

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -91,6 +91,12 @@ export default class ObsidianWakatime extends Plugin {
 		this.registerDomEvent(activeDocument, 'keydown', () => {
 			this.onEvent(false);
 		});
+		this.registerDomEvent(activeDocument, 'scroll', () => {
+			this.onEvent(false);
+		}, {capture: true});
+		this.registerDomEvent(activeDocument, 'touchmove', () => {
+			this.onEvent(false);
+		});
 	}
 
 	private onEvent(isWrite: boolean) {


### PR DESCRIPTION
Only `click` and `keydown` currently trigger heartbeats, so reading a note generates none — reading is scrolling. The plugin description says it tracks time spent "browsing or writing notes", but browsing isn't tracked today.

This adds `scroll` and `touchmove` to `setupEventListeners`. `scroll` needs `{capture: true}`: scroll events don't bubble, and Obsidian scrolls inside `.cm-scroller` / `.markdown-preview-view`, so a listener on `activeDocument` never fires without it.

No change for existing setups. Both new events go through the same `onEvent` → `enoughTimePassed()` path, so the heartbeat rate is unchanged — they can only add heartbeats in sessions that previously sent none. Nothing about the payload, endpoint, or Wakapi handling changes.

`touchmove` also makes tracking work on mobile, where there's no keyboard and reading is entirely scrolling.

Tested against a self-hosted Wakapi instance.
